### PR TITLE
Fix inputs based on dir path

### DIFF
--- a/src/wdlci/wdl_tests/check_comma_separated.wdl
+++ b/src/wdlci/wdl_tests/check_comma_separated.wdl
@@ -10,7 +10,6 @@ task check_comma_separated {
 	}
 
 	Int disk_size = ceil(size(current_run_output, "GB") + size(validated_output, "GB") + 50)
-	String current_run_output_unzipped = sub(current_run_output, "\\.gz$", "")
 
 	command <<<
 		set -euo pipefail
@@ -27,12 +26,13 @@ task check_comma_separated {
 
 		# Validated dir path in input block vs. command block is different
 		validated_dir_path=$(dirname ~{validated_output})
+		current_dir_path=$(dirname ~{current_run_output})
 
 		if ! awk '{exit !/,/}' "${validated_dir_path}/$(basename ~{validated_output} .gz)"; then
 			err "Validated file: [~{basename(validated_output)}] is not comma-separated"
 			exit 1
 		else
-			if awk '{exit !/,/}' ~{current_run_output_unzipped}; then
+			if awk '{exit !/,/}' "${current_dir_path}/$(basename ~{current_run_output} .gz)"; then
 				echo "Current run file: [~{basename(current_run_output)}] is comma-separated"
 			else
 				err "Current run file: [~{basename(current_run_output)}] is not comma-separated"

--- a/src/wdlci/wdl_tests/count_bed_columns.wdl
+++ b/src/wdlci/wdl_tests/count_bed_columns.wdl
@@ -10,7 +10,6 @@ task count_bed_columns {
 	}
 
 	Int disk_size = ceil(size(current_run_output, "GB") + size(validated_output, "GB") + 50)
-	String current_run_output_unzipped = sub(current_run_output, "\\.gz$", "")
 
 	command <<<
 		set -euo pipefail
@@ -23,11 +22,12 @@ task count_bed_columns {
 
 		# Validated dir path in input block vs. command block is different
 		validated_dir_path=$(dirname ~{validated_output})
+		current_dir_path=$(dirname ~{current_run_output})
 
 		if gzip -t ~{current_run_output}; then
 			gzip -d ~{current_run_output} ~{validated_output}
 			# Assuming header does not start with chr...
-			current_run_output_column_count=$(sed '/^chr/!d' ~{current_run_output_unzipped} | awk '{print NF}' | sort -nu | tail -n 1)
+			current_run_output_column_count=$(sed '/^chr/!d' "${current_dir_path}/$(basename ~{current_run_output} .gz)" | awk '{print NF}' | sort -nu | tail -n 1)
 			validated_output_column_count=$(sed '/^chr/!d' "${validated_dir_path}/$(basename ~{validated_output} .gz)" | awk '{print NF}' | sort -nu | tail -n 1)
 		else
 			current_run_output_column_count=$(sed '/^chr/!d' ~{current_run_output} | awk '{print NF}' | sort -nu | tail -n 1)


### PR DESCRIPTION
Dir path in input block vs. command block is different. Fix this for inputs in wdl_tests.