### PR TITLE
Feature/disable linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ If any step of the action fails, the check will fail; however if some task tests
     # WDL test files specified as tests in the config-file prior to searching through tests
     # defined in src/wdlci/wdl_tests
     wdl_ci_custom_test_wdl_dir: ''
+
+    # Suppress lint warnings and errors
+    # Useful if you're setting up tests for external workflows that you do not have the ability to fix errors for
+    # Default: false (fail the action on unsuppressed warning or error)
+    suppress-lint-errors: false
 ```
 
 # Scenarios

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   wdl_ci_custom_test_wdl_dir:
     description: Directory to find custom test WDLs in
     required: false
+  suppress-lint-errors:
+    description: Continue upon encountering a linting warning or error
+    default: false
 runs:
   using: 'composite'
   steps:
@@ -52,7 +55,7 @@ runs:
     - name: lint
       uses: docker://dnastack/wdl-ci:v1.0.0
       with:
-        args: lint
+        args: lint ${{ inputs.suppress_lint_errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
       uses: docker://dnastack/wdl-ci:v1.0.0
       with:

--- a/src/wdlci/cli/__main__.py
+++ b/src/wdlci/cli/__main__.py
@@ -25,6 +25,15 @@ update_digests_option = click.option(
     help="Update the task digests for tasks that completed their tests successfully",
 )
 
+suppress_lint_errors_option = click.option(
+    "--suppress-lint-errors",
+    "-s",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Do not exit upon encountering a linting warning or error",
+)
+
 
 @click.group(cls=OrderedGroup)
 def main():
@@ -43,6 +52,7 @@ def generate_config(**kwargs):
 
 
 @main.command
+@suppress_lint_errors_option
 def lint(**kwargs):
     """Lint a WDL workflow"""
 

--- a/src/wdlci/cli/lint.py
+++ b/src/wdlci/cli/lint.py
@@ -10,6 +10,9 @@ from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
 
 
 def lint_handler(kwargs):
+    suppress_lint_errors = kwargs["suppress_lint_errors"]
+    print(f"Suppress lint errors: {suppress_lint_errors}")
+
     try:
         Config.load(kwargs)
         config = Config.instance()
@@ -43,10 +46,13 @@ def lint_handler(kwargs):
             print()
 
         if len(lint_failed_workflows) > 0:
-            raise WdlTestCliExitException(
-                f"Unsuppressed warnings or errors in workflows {lint_failed_workflows}",
-                1,
-            )
+            if suppress_lint_errors:
+                print(f"[WARN] Suppressing lint errors in {lint_failed_workflows}")
+            else:
+                raise WdlTestCliExitException(
+                    f"Unsuppressed warnings or errors in workflows {lint_failed_workflows}",
+                    1,
+                )
 
     except WdlTestCliExitException as e:
         print(f"exiting with code {e.exit_code}, message: {e.message}")


### PR DESCRIPTION
## Features
- Allow lint warnings and errors to be suppressed. Recommended not to turn this on unless you really need it (e.g. you are testing external workflows that you do not want to modify).