### PR TITLE
v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If any step of the action fails, the check will fail; however if some task tests
     # Directory containing custom test WDLs. If defined, this directory will be searched for
     # WDL test files specified as tests in the config-file prior to searching through tests
     # defined in src/wdlci/wdl_tests
-    wdl_ci_custom_test_wdl_dir: ''
+    wdl-ci-custom-test-wdl-dir: ''
 
     # Suppress lint warnings and errors
     # Useful if you're setting up tests for external workflows that you do not have the ability to fix errors for
@@ -133,7 +133,7 @@ jobs:
 
 ## Extend the tests available to wdl-ci
 
-Define the `wdl_ci_custom_test_wdl_dir` to specify a directory containing custom WDL-based tests; these test tasks may then be used to test workflow tasks. See [WDL-based tests](#wdl-based-tests) for more information on writing custom test tasks. The `wdl_ci_custom_test_wdl_dir` should refer to a directory that exists in the target repository.
+Define the `wdl-ci-custom-test-wdl-dir` to specify a directory containing custom WDL-based tests; these test tasks may then be used to test workflow tasks. See [WDL-based tests](#wdl-based-tests) for more information on writing custom test tasks. The `wdl-ci-custom-test-wdl-dir` should refer to a directory that exists in the target repository.
 
 ```yaml
 name: Lint and test workflows
@@ -159,7 +159,7 @@ jobs:
           workbench-workflow-service-url:  ${{ secrets.WORKBENCH_WORKFLOW_SERVICE_URL }}
           workbench-ewes-refresh-token: ${{ secrets.WORKBENCH_EWES_REFRESH_TOKEN }}
           workbench-workflow-service-refresh-token: ${{ secrets.WORKBENCH_WORKFLOW_SERVICE_REFRESH_TOKEN }}
-          wdl_ci_custom_test_wdl_dir: my-custom-test-dir
+          wdl-ci-custom-test-wdl-dir: my-custom-test-dir
 ```
 
 # Configuring and installing the GitHub action
@@ -406,7 +406,7 @@ It is not necessary to test every item in the current run output array, but keep
 
 ## Custom tests
 
-Custom test WDLs may be defined in a directory located in the target repository. To allow `wdl-ci` access to custom tests, the `WDL_CI_CUSTOM_TEST_WDL_DIR` environment variable must be set (GitHub action: [run with `wdl_ci_custom_test_wdl_dir` set](#extend-the-tests-available-to-wdl-ci)).
+Custom test WDLs may be defined in a directory located in the target repository. To allow `wdl-ci` access to custom tests, the `WDL_CI_CUSTOM_TEST_WDL_DIR` environment variable must be set (GitHub action: [run with `wdl-ci-custom-test-wdl-dir` set](#extend-the-tests-available-to-wdl-ci)).
 
 
 # Local installation

--- a/README.md
+++ b/README.md
@@ -331,10 +331,11 @@ Multiple engines can be configured. Tests will be submitted to all enabled engin
 Test params can be used to avoid repeating paths and values for test inputs and outputs.
 
 - Parameters defined here can be used in inputs and outputs for task tests in the format `${param_name}`; these will be replaced with the `<param_value>` for workflow submission
+- For parameters whose value is an object, object members can be accessed using `.`s: `"reference_index": ${reference.fasta.data_index}`
 - Global params will replace values for all engines
 - Engine params will replace values only when submitting to a particular engine; useful if for example input sets exist across multiple environments and are prefixed with different paths
-- Objects and arrays can be used for parameters; if you are using a complex parameter as an input or output value, this parameter must be the only content of the value, e.g. `"my_input": "${complex_param}"`, not `"my_input": "${complex_param}.some_key"`
-- Complex parameters can themselves use parameters, and will be substituted appropriately
+- Objects and arrays can be used for parameters; if you are using a complex parameter as an input or output value, this parameter must be the only content of the value, e.g. `"my_input": "${complex_param}"`, not `"my_input": "gs://my_bucket/${complex_param}"`
+- The values of complex parameters can themselves use parameters, and will be substituted appropriately
 
 ```json
 "test_params": {

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ If an input is a file, the value should be the path to the file on the filesyste
 Outputs from the task to be tested. Not all outputs must be defined or tested. This field is an object containing one entry per output to be tested, where the object key is the name of the output and the value is an object with keys:
 
 - `value`: Validated output of the task from a previous run.
-- `test_tasks`: This specifies the array of tests that should be applied to a specific output. See [WDL-based tests](#WDL-based-tests) for information on defining and using test tasks on ourputs.
+- `test_tasks`: This specifies the array of tests that should be applied to a specific output. See [WDL-based tests](#WDL-based-tests) for information on defining and using test tasks on outputs.
 
 
 ```json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If any step of the action fails, the check will fail; however if some task tests
 # GitHub action usage
 
 ```yaml
-- uses: dnastack/wdl-ci@v1.0.0
+- uses: dnastack/wdl-ci@v2.0.0
   with:
     # Configuration file where tests can be found
     # Default: wdl-ci.config.json
@@ -91,7 +91,7 @@ jobs:
         with:
           submodules: true
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v1.0.0
+        uses: dnastack/wdl-ci@v2.0.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -119,7 +119,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v1.0.0
+        uses: dnastack/wdl-ci@v2.0.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -149,7 +149,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v1.0.0
+        uses: dnastack/wdl-ci@v2.0.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ If any step of the action fails, the check will fail; however if some task tests
     # WDL test files specified as tests in the config-file prior to searching through tests
     # defined in src/wdlci/wdl_tests
     wdl_ci_custom_test_wdl_dir: ''
+
+    # Suppress lint warnings and errors
+    # Useful if you're setting up tests for external workflows that you do not have the ability to fix errors for
+    # Default: false (fail the action on unsuppressed warning or error)
+    suppress-lint-errors: false
 ```
 
 # Scenarios

--- a/README.md
+++ b/README.md
@@ -291,6 +291,30 @@ Each test task will be passed the validated output as well as the output from th
 
 Output values can use parameters defined in [test_params](#test_params).
 
+##### Testing struct member outputs
+
+Primitive structs members may be individually tested by referring to their path, e.g. `struct.member`. For example, for the following struct:
+
+```wdl
+struct Sample {
+  String sample_id
+  File summary_file
+}
+```
+
+For the case where the output of a task is `Sample my_sample`, the `sample_id` field can be tested as follows:
+
+```json
+"output_tests": {
+  "my_sample.sample_id": {
+    "value": "NA12878",
+    "test_tasks": [
+      "compare_string"
+    ]
+  }
+}
+```
+
 ### `engines`
 
 **Do not configure an engine that has access to protected health information, even if that data is not being used in tests.** Ideally a workflow engine that is used only for testing and has access only to non-protected test input files should be used.

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   workbench-workflow-service-refresh-token:
     description: Workbench Workflow Service Refresh Token
     required: true
-  wdl_ci_custom_test_wdl_dir:
+  wdl-ci-custom-test-wdl-dir:
     description: Directory to find custom test WDLs in
     required: false
   suppress-lint-errors:
@@ -49,8 +49,8 @@ runs:
         echo "WORKBENCH_WORKFLOW_SERVICE_URL=${{ inputs.workbench-workflow-service-url }}" >> $GITHUB_ENV
         echo "WORKBENCH_EWES_REFRESH_TOKEN=${{ inputs.workbench-ewes-refresh-token }}" >> $GITHUB_ENV
         echo "WORKBENCH_WORKFLOW_SERVICE_REFRESH_TOKEN=${{ inputs.workbench-workflow-service-refresh-token }}" >> $GITHUB_ENV
-        if [[ -n "${{ inputs.wdl_ci_custom_test_wdl_dir }}" ]]; then
-          echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl_ci_custom_test_wdl_dir }} >> $GITHUB_ENV
+        if [[ -n "${{ inputs.wdl-ci-custom-test-wdl-dir }}" ]]; then
+          echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl-ci-custom-test-wdl-dir }} >> $GITHUB_ENV
         fi
     - name: lint
       uses: docker://dnastack/wdl-ci:v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   wdl_ci_custom_test_wdl_dir:
     description: Directory to find custom test WDLs in
     required: false
+  suppress-lint-errors:
+    description: Continue upon encountering a linting warning or error
+    default: false
 runs:
   using: 'composite'
   steps:
@@ -52,7 +55,7 @@ runs:
     - name: lint
       uses: docker://dnastack/wdl-ci:v1.0.0
       with:
-        args: lint
+        args: lint ${{ inputs.suppress_lint_errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
       uses: docker://dnastack/wdl-ci:v1.0.0
       with:

--- a/action.yml
+++ b/action.yml
@@ -53,19 +53,19 @@ runs:
           echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl-ci-custom-test-wdl-dir }} >> $GITHUB_ENV
         fi
     - name: lint
-      uses: docker://dnastack/wdl-ci:v1.0.0
+      uses: docker://dnastack/wdl-ci:v2.0.0
       with:
         args: lint ${{ inputs.suppress_lint_errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
-      uses: docker://dnastack/wdl-ci:v1.0.0
+      uses: docker://dnastack/wdl-ci:v2.0.0
       with:
         args: detect-changes
     - name: submit
-      uses: docker://dnastack/wdl-ci:v1.0.0
+      uses: docker://dnastack/wdl-ci:v2.0.0
       with:
         args: submit
     - name: monitor
-      uses: docker://dnastack/wdl-ci:v1.0.0
+      uses: docker://dnastack/wdl-ci:v2.0.0
       with:
         args: monitor --update-digests
       # If a test fails, still update task digests for any tests that succeeded
@@ -79,6 +79,6 @@ runs:
         default_author: github_actions
     - name: cleanup
       if: always()
-      uses: docker://dnastack/wdl-ci:v1.0.0
+      uses: docker://dnastack/wdl-ci:v2.0.0
       with:
         args: cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wdl-testing-cli"
 description = "DNAstack WDL testing CLI"
-version = "1.0.0"
+version = "2.0.0"
 authors = [
     { name = "DNAstack", email = "devs@dnastack.com" }
 ]

--- a/src/wdlci/cli/__main__.py
+++ b/src/wdlci/cli/__main__.py
@@ -25,6 +25,15 @@ update_digests_option = click.option(
     help="Update the task digests for tasks that completed their tests successfully",
 )
 
+suppress_lint_errors_option = click.option(
+    "--suppress-lint-errors",
+    "-s",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Do not exit upon encountering a linting warning or error",
+)
+
 
 @click.group(cls=OrderedGroup)
 def main():
@@ -43,6 +52,7 @@ def generate_config(**kwargs):
 
 
 @main.command
+@suppress_lint_errors_option
 def lint(**kwargs):
     """Lint a WDL workflow"""
 

--- a/src/wdlci/cli/lint.py
+++ b/src/wdlci/cli/lint.py
@@ -10,6 +10,9 @@ from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
 
 
 def lint_handler(kwargs):
+    suppress_lint_errors = kwargs["suppress_lint_errors"]
+    print(f"Suppress lint errors: {suppress_lint_errors}")
+
     try:
         Config.load(kwargs)
         config = Config.instance()
@@ -43,10 +46,13 @@ def lint_handler(kwargs):
             print()
 
         if len(lint_failed_workflows) > 0:
-            raise WdlTestCliExitException(
-                f"Unsuppressed warnings or errors in workflows {lint_failed_workflows}",
-                1,
-            )
+            if suppress_lint_errors:
+                print(f"[WARN] Suppressing lint errors in {lint_failed_workflows}")
+            else:
+                raise WdlTestCliExitException(
+                    f"Unsuppressed warnings or errors in workflows {lint_failed_workflows}",
+                    1,
+                )
 
     except WdlTestCliExitException as e:
         print(f"exiting with code {e.exit_code}, message: {e.message}")

--- a/src/wdlci/cli/submit.py
+++ b/src/wdlci/cli/submit.py
@@ -152,7 +152,7 @@ def submit_handler(kwargs):
 
                     source_params = {
                         **config.file.test_params.global_params,
-                        **config.file.test_params.engine_params[engine_id],
+                        **config.file.test_params.engine_params.get(engine_id, {}),
                     }
                     inputs_hydrated = HydrateParams.hydrate(
                         source_params,
@@ -166,7 +166,7 @@ def submit_handler(kwargs):
                         output_test_key,
                         output_test_val,
                     ) in test_case.output_tests.items():
-                        output_test_key_hydrated = f"{task_config['workflow_name']}.TEST_OUTPUT_{output_test_key}"
+                        output_test_key_hydrated = f"{task_config['workflow_name']}.TEST_OUTPUT_{output_test_key.replace('.', '_')}"
                         output_test_val_hydrated = HydrateParams.hydrate(
                             source_params, output_test_val, update_key=False
                         )

--- a/src/wdlci/utils/hydrate_params.py
+++ b/src/wdlci/utils/hydrate_params.py
@@ -1,6 +1,14 @@
 import re
+import copy
+from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
 
 variable_regex = re.compile("\${[^}]+}")
+# The entire target value is enclosed in a variable
+#   ${reference.reference_fasta}
+subvariable_regex = re.compile("^\${[^{}\$]+\.[^{}\$]+}$")
+# The target value is comprised of variable and non-variable segments: not supported
+#   gs://my_bucket/${reference.reference_fasta}
+subvariable_regex_nonvar = re.compile("\${[^{}\$]+\.[^{}\$]+}")
 
 
 class HydrateParams(object):
@@ -9,8 +17,18 @@ class HydrateParams(object):
         result = {}
         separator = "" if workflow_name == "" else "."
 
-        def _replace_value_recursive(target_value):
+        def _replace_value_recursive(target_value, subkeys=[]):
             if type(target_value) is str and variable_regex.search(target_value):
+                # Referring to struct members, e.g. reference.reference_fasta
+                if subvariable_regex.search(target_value):
+                    object_selector = target_value.lstrip("${").rstrip("}").split(".")
+                    target_value = "${" + object_selector[0] + "}"
+                    subkeys = object_selector[1:]
+                elif subvariable_regex_nonvar.search(target_value):
+                    raise WdlTestCliExitException(
+                        f'Selecting struct members when this selector is not the only item present in the target value is not currently supported.\nTry again using only:\n\t"${{key.subkey[.subkey]}}"\nYou had:\n\t"{target_value}"',
+                        1,
+                    )
                 for source_key, source_value in source.items():
                     # Don't try replacing the source value when it's non-string
                     # Need to keep checking that target_value is still str because it could be replaced with a complex object
@@ -26,17 +44,18 @@ class HydrateParams(object):
                             rf"^\${{{source_key}}}$", target_value
                         ):
                             source_value_substituted = _replace_value_recursive(
-                                source_value
+                                source_value, subkeys
                             )
                             target_value = source_value_substituted
                         # If the source key is found in the target_value but is not the only contents of target_value, emit an error
                         elif type(target_value) is str and re.search(
                             rf"\${{{source_key}}}", target_value
                         ):
-                            raise SystemExit(
-                                f'[ERROR] Cannot set complex parameter {source_key} for target key [{target_key}]; in order to set a non-string parameter (e.g. dict or array) to a value it must be the sole content of the target\nAllowed:\n\t"{target_key}": "${{{source_key}}}"\nYou had:\n\t"{target_key}": "{target_value}"'
+                            raise WdlTestCliExitException(
+                                f'[ERROR] Cannot set complex parameter {source_key} for target key [{target_key}]; in order to set a non-string parameter (e.g. dict or array) to a value it must be the sole content of the target\nAllowed:\n\t"{target_key}": "${{{source_key}}}"\nYou had:\n\t"{target_key}": "{target_value}"',
+                                1,
                             )
-                return _replace_value_recursive(target_value)
+                return _replace_value_recursive(target_value, subkeys)
             # If the target_value is type string and no longer has any variables to substitute
             elif type(target_value) is str:
                 return target_value
@@ -49,12 +68,30 @@ class HydrateParams(object):
                 substituted_dict = dict()
                 for key, value in target_value.items():
                     substituted_dict[key] = _replace_value_recursive(value)
-                return substituted_dict
+                if len(subkeys) > 0:
+                    substituted_value = copy.deepcopy(substituted_dict)
+                    for subkey in subkeys:
+                        if type(substituted_value) is not dict:
+                            raise WdlTestCliExitException(
+                                f"Cannot select key '{subkey}' from non-dict '{substituted_value}'; check your data structure?\nInitial dict being traversed:\n{substituted_dict}",
+                                1,
+                            )
+                        try:
+                            substituted_value = substituted_value[subkey]
+                        except KeyError:
+                            raise WdlTestCliExitException(
+                                f"Key '{subkey}' not found in {substituted_value.keys()}.\nInitial dict being traversed:\n{substituted_dict}",
+                                1,
+                            )
+                    return substituted_value
+                else:
+                    return substituted_dict
             elif type(target_value) is int or type(target_value) is bool:
                 return target_value
             else:
-                raise SystemExit(
-                    f"Unexpected type [{type(target_value)}] detected for value {target_value}"
+                raise WdlTestCliExitException(
+                    f"Unexpected type [{type(target_value)}] detected for value {target_value}",
+                    1,
                 )
 
         for target_key, target_value in target.items():
@@ -64,4 +101,5 @@ class HydrateParams(object):
                 f"{workflow_name}{separator}{target_key}" if update_key else target_key
             )
             result[new_key] = target_value_substituted
+
         return result

--- a/src/wdlci/wdl_tests/check_comma_separated.wdl
+++ b/src/wdlci/wdl_tests/check_comma_separated.wdl
@@ -10,7 +10,6 @@ task check_comma_separated {
 	}
 
 	Int disk_size = ceil(size(current_run_output, "GB") + size(validated_output, "GB") + 50)
-	String current_run_output_unzipped = sub(current_run_output, "\\.gz$", "")
 
 	command <<<
 		set -euo pipefail
@@ -27,12 +26,13 @@ task check_comma_separated {
 
 		# Validated dir path in input block vs. command block is different
 		validated_dir_path=$(dirname ~{validated_output})
+		current_dir_path=$(dirname ~{current_run_output})
 
 		if ! awk '{exit !/,/}' "${validated_dir_path}/$(basename ~{validated_output} .gz)"; then
 			err "Validated file: [~{basename(validated_output)}] is not comma-separated"
 			exit 1
 		else
-			if awk '{exit !/,/}' ~{current_run_output_unzipped}; then
+			if awk '{exit !/,/}' "${current_dir_path}/$(basename ~{current_run_output} .gz)"; then
 				echo "Current run file: [~{basename(current_run_output)}] is comma-separated"
 			else
 				err "Current run file: [~{basename(current_run_output)}] is not comma-separated"

--- a/src/wdlci/wdl_tests/count_bed_columns.wdl
+++ b/src/wdlci/wdl_tests/count_bed_columns.wdl
@@ -10,7 +10,6 @@ task count_bed_columns {
 	}
 
 	Int disk_size = ceil(size(current_run_output, "GB") + size(validated_output, "GB") + 50)
-	String current_run_output_unzipped = sub(current_run_output, "\\.gz$", "")
 
 	command <<<
 		set -euo pipefail
@@ -23,11 +22,12 @@ task count_bed_columns {
 
 		# Validated dir path in input block vs. command block is different
 		validated_dir_path=$(dirname ~{validated_output})
+		current_dir_path=$(dirname ~{current_run_output})
 
 		if gzip -t ~{current_run_output}; then
 			gzip -d ~{current_run_output} ~{validated_output}
 			# Assuming header does not start with chr...
-			current_run_output_column_count=$(sed '/^chr/!d' ~{current_run_output_unzipped} | awk '{print NF}' | sort -nu | tail -n 1)
+			current_run_output_column_count=$(sed '/^chr/!d' "${current_dir_path}/$(basename ~{current_run_output} .gz)" | awk '{print NF}' | sort -nu | tail -n 1)
 			validated_output_column_count=$(sed '/^chr/!d' "${validated_dir_path}/$(basename ~{validated_output} .gz)" | awk '{print NF}' | sort -nu | tail -n 1)
 		else
 			current_run_output_column_count=$(sed '/^chr/!d' ~{current_run_output} | awk '{print NF}' | sort -nu | tail -n 1)


### PR DESCRIPTION
# v2.0.0
## Features
- The members of structs that are output by tasks may now be individually tested (rather than needing to test the entire contents of the struct)
- Members from variables that are objects may be selected using `${variable.key[.subkey...]}`
- Linting may be disabled by setting `suppress-lint-errors` in the action input to `true`

## Bugfixes
- Engine parameters in the config file are allowed to be empty
- The `check_comma_separated` test now works in GCP

## Breaking changes
- The `wdl_ci_custom_test_wdl_dir` variable was renamed to `wdl-ci-custom-test-wdl-dir` to make input syntax consistent.
