### PR TITLE
Add type float as acceptable type for target_value

### DIFF
--- a/src/wdlci/utils/hydrate_params.py
+++ b/src/wdlci/utils/hydrate_params.py
@@ -86,7 +86,11 @@ class HydrateParams(object):
                     return substituted_value
                 else:
                     return substituted_dict
-            elif type(target_value) is int or type(target_value) is bool:
+            elif (
+                type(target_value) is int
+                or type(target_value) is bool
+                or type(target_value) is float
+            ):
                 return target_value
             else:
                 raise WdlTestCliExitException(


### PR DESCRIPTION
Floats are not currently an accepted variable type for `target_value` and the inclusion of any inputs of type float would raise a `WdlTestCliExitException`. Adjusted the elif statement to accept float values. 