### PR TITLE
Feature/add-version-arg

### DIFF
--- a/src/wdlci/cli/__main__.py
+++ b/src/wdlci/cli/__main__.py
@@ -36,6 +36,9 @@ suppress_lint_errors_option = click.option(
 
 
 @click.group(cls=OrderedGroup)
+@click.version_option(
+    package_name="wdl-testing-cli", message="%(prog)s version:%(version)s"
+)
 def main():
     """Validate and test WDL workflows"""
 


### PR DESCRIPTION
## Features
- Allows users to determine the version of wdl-ci being run using the `--version` flag after invoking `wdl-ci`. The Click library will detect the version using `importlib.metadata.version`, which retrieves the version from the [pyproject.toml file](https://github.com/DNAstack/wdl-ci/blob/main/pyproject.toml#L4).