### PR TITLE
Feature/handle-refresh-token-expiring-errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
     "dnastack-client-library",
     "jsonpickle",
     "miniwdl",
-    "requests"
+    "requests",
+    "pyjwt[crypto]"
 ]
 
 [build-system]

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -14,7 +14,6 @@ class RefreshTokenAuth(object):
         self.scopes = scopes
         self._access_token = None
         self._access_token_issued_at = None
-        self.check_refresh_token_expiry()
 
     @property
     def access_token(self):
@@ -44,6 +43,8 @@ class RefreshTokenAuth(object):
 
     def __obtain_access_token(self):
         env = Config.instance().env
+
+        self.check_refresh_token_expiry()
 
         url = f"{env.wallet_url}/oauth/token"
         params = {

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -2,7 +2,6 @@ import base64
 import datetime
 import requests
 import jwt
-import sys
 from wdlci.config import Config
 from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
 

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -63,7 +63,7 @@ class RefreshTokenAuth(object):
         response = requests.post(url, params=params, headers=headers)
         if response.status_code != 200:
             raise WdlTestCliExitException(
-                "The refresh token is not expired, but still could not obtain access token from refresh token. Please ensure the refresh token provided as a Github action secret is valid",
+                "The refresh token is not expired, but still could not obtain access token from refresh token. Please ensure the refresh token provided as a GitHub action secret is valid",
                 1,
             )
 

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -38,15 +38,17 @@ class RefreshTokenAuth(object):
             print(f"The refresh token expires as of {expiry}")
         except jwt.exceptions.ExpiredSignatureError as e:
             expiry = datetime.datetime.fromtimestamp(decoded["exp"])
-            print(
-                f"The refresh token is expired as of {expiry}, message: {e}. The GitHub actions secrets will need to be updated with a new refresh token."
+            print(f"The refresh token is expired as of {expiry}, message: {e}.")
+            raise WdlTestCliExitException(
+                "The refresh token is expired, the GitHub actions secrets will need to be updated with a new refresh token.",
+                1,
             )
-            sys.exit(1)
         except jwt.exceptions.InvalidTokenError as e:
-            print(
-                f"Error decoding token: {e}. Please ensure you are providing a valid refresh token."
+            print(f"Error decoding token: {e}.")
+            raise WdlTestCliExitException(
+                "Please ensure you are providing a valid refresh token.",
+                1,
             )
-            sys.exit(1)
 
     def __obtain_access_token(self):
         env = Config.instance().env

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -30,12 +30,12 @@ class RefreshTokenAuth(object):
         return self._access_token
 
     def check_refresh_token_expiry(self):
-        token = self.refresh_token
-
         try:
             decoded = jwt.decode(
                 self.refresh_token, options={"verify_signature": False}
             )
+            expiry = datetime.datetime.fromtimestamp(decoded["exp"])
+            print(expiry)
         except jwt.ExpiredSignatureError as e:
             expiry = datetime.datetime.fromtimestamp(decoded["exp"])
             print(

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -30,25 +30,18 @@ class RefreshTokenAuth(object):
         return self._access_token
 
     def check_refresh_token_expiry(self):
-        try:
-            decoded = jwt.decode(
-                self.refresh_token, options={"verify_signature": False}
-            )
-            expiry = datetime.datetime.fromtimestamp(decoded["exp"])
-            print(f"The refresh token expires as of {expiry}")
-        except jwt.exceptions.ExpiredSignatureError as e:
-            expiry = datetime.datetime.fromtimestamp(decoded["exp"])
-            print(f"The refresh token is expired as of {expiry}, message: {e}.")
+        decoded = jwt.decode(self.refresh_token, options={"verify_signature": False})
+        expiry = datetime.datetime.fromtimestamp(decoded["exp"])
+        now = datetime.datetime.now()
+
+        if expiry < now:
+            print(f"The refresh token is expired as of {expiry}")
             raise WdlTestCliExitException(
                 "The refresh token is expired, the GitHub actions secrets will need to be updated with a new refresh token.",
                 1,
             )
-        except jwt.exceptions.InvalidTokenError as e:
-            print(f"Error decoding token: {e}.")
-            raise WdlTestCliExitException(
-                "Please ensure you are providing a valid refresh token.",
-                1,
-            )
+        else:
+            print(f"The refresh token is valid, but will expire as of {expiry}")
 
     def __obtain_access_token(self):
         env = Config.instance().env

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -35,8 +35,8 @@ class RefreshTokenAuth(object):
                 self.refresh_token, options={"verify_signature": False}
             )
             expiry = datetime.datetime.fromtimestamp(decoded["exp"])
-            print(expiry)
-        except jwt.ExpiredSignatureError as e:
+            print(f"The refresh token expires as of {expiry}")
+        except jwt.exceptions.ExpiredSignatureError as e:
             expiry = datetime.datetime.fromtimestamp(decoded["exp"])
             print(
                 f"The refresh token is expired as of {expiry}, message: {e}. The GitHub actions secrets will need to be updated with a new refresh token."

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -63,7 +63,7 @@ class RefreshTokenAuth(object):
         response = requests.post(url, params=params, headers=headers)
         if response.status_code != 200:
             raise WdlTestCliExitException(
-                "The refresh token is not expired, but still could not obtain access token from refresh token. Please ensure the refresh token provided as a GitHub action secret is valid",
+                "could not obtain access token from refresh token",
                 1,
             )
 

--- a/src/wdlci/auth/refresh_token_auth.py
+++ b/src/wdlci/auth/refresh_token_auth.py
@@ -63,7 +63,8 @@ class RefreshTokenAuth(object):
         response = requests.post(url, params=params, headers=headers)
         if response.status_code != 200:
             raise WdlTestCliExitException(
-                "could not obtain access token from refresh token", 1
+                "The refresh token is not expired, but still could not obtain access token from refresh token. Please ensure the refresh token provided as a Github action secret is valid",
+                1,
             )
 
         response_json = response.json()


### PR DESCRIPTION
Added a function to check if the refresh token is expired and raises an exception if so. If it's valid, the expiry datetime will still be printed.