### PR TITLE
bugfix/newline-array-separator

### DIFF
--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -260,7 +260,7 @@ def _write_task(doc_task, output_file):
         if newline_children:
             for child in newline_children:
                 print(
-                    "\nWarning: it looks like a literal newline was present as a separator in "
+                    "\n[WARN]: it looks like a literal newline was present as a separator in "
                     "your command and may need to be escaped."
                 )
                 modified_child = str(child).replace("\n", "\\n")

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -247,6 +247,34 @@ def _write_task(doc_task, output_file):
 
         ## Command
         f.write("\tcommand <<<\n")
+        original_command = str(doc_task.command)
+
+        # Use a generator expression to iterate over doc_task.command children and
+        # check if any contain newline characters and a specified separator and
+        # ensure the separator precedes '\n'
+        newline_children = [
+            c
+            for c in doc_task.command.children
+            if "\n" in str(c)
+            and "sep=" in str(c)
+            and str(c).index("sep=") < str(c).index("\n")
+        ]
+        if newline_children:
+            for child in newline_children:
+                print(
+                    "\nWarning: it looks like a literal newline was present as a separator in "
+                    "your command and may need to be escaped."
+                )
+                child_str = str(child).replace("\n", "\\n")
+                modified_command = original_command.replace(str(child), child_str)
+                print(
+                    "The literal newline was escaped and replaced with the literal '\\n' as:\n "
+                    f"{modified_command}\nIf this is not intended, escape the newline character in "
+                    "your workflow manually.\n"
+                )
+                f.write(f"\t\t{modified_command}\n")
+        else:
+            f.write(f"\t\t{original_command}\n")
         f.write(f"\t\t{doc_task.command}\n")
         f.write("\t>>>\n")
         f.write("\n")

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 from importlib.resources import files
 from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
+import linecache
 
 
 def _order_structs(struct_typedefs):
@@ -246,35 +247,9 @@ def _write_task(doc_task, output_file):
         f.write("\n")
 
         ## Command
-        f.write("\tcommand <<<\n")
-        original_command = str(doc_task.command)
-        # Create list of task children and check if there is an instance
-        # of a newline character being used as a separator that will be interpreted literally
-        newline_children = [
-            c
-            for c in doc_task.command.children
-            if "\n" in str(c)
-            and "sep=" in str(c)
-            and str(c).index("sep=") < str(c).index("\n")
-        ]
-        if newline_children:
-            for child in newline_children:
-                print(
-                    "\n[WARN]: it looks like a literal newline was present as a separator in "
-                    "your command and may need to be escaped."
-                )
-                modified_child = str(child).replace("\n", "\\n")
-                modified_command = original_command.replace(str(child), modified_child)
-                print(
-                    "The literal newline was escaped and replaced with the literal '\\n' as:\n "
-                    f"{modified_command}\nIf this is not intended, escape the newline character in "
-                    "your workflow manually.\n"
-                )
-                f.write(f"\t\t{modified_command}\n")
-        else:
-            f.write(f"\t\t{original_command}\n")
-        f.write("\t>>>\n")
-        f.write("\n")
+        command_pos = doc_task.command.pos
+        for line_no in range(command_pos.line, command_pos.end_line + 1):
+            f.write(linecache.getline(command_pos.abspath, line_no))
 
         ## Outputs
         f.write("\toutput {\n")

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -248,10 +248,8 @@ def _write_task(doc_task, output_file):
         ## Command
         f.write("\tcommand <<<\n")
         original_command = str(doc_task.command)
-
-        # Use a generator expression to iterate over doc_task.command children and
-        # check if any contain newline characters and a specified separator and
-        # ensure the separator precedes '\n'
+        # Create list of task children and check if there is an instance
+        # of a newline character being used as a separator that will be interpreted literally
         newline_children = [
             c
             for c in doc_task.command.children
@@ -265,8 +263,8 @@ def _write_task(doc_task, output_file):
                     "\nWarning: it looks like a literal newline was present as a separator in "
                     "your command and may need to be escaped."
                 )
-                child_str = str(child).replace("\n", "\\n")
-                modified_command = original_command.replace(str(child), child_str)
+                modified_child = str(child).replace("\n", "\\n")
+                modified_command = original_command.replace(str(child), modified_child)
                 print(
                     "The literal newline was escaped and replaced with the literal '\\n' as:\n "
                     f"{modified_command}\nIf this is not intended, escape the newline character in "

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -273,7 +273,6 @@ def _write_task(doc_task, output_file):
                 f.write(f"\t\t{modified_command}\n")
         else:
             f.write(f"\t\t{original_command}\n")
-        f.write(f"\t\t{doc_task.command}\n")
         f.write("\t>>>\n")
         f.write("\n")
 


### PR DESCRIPTION
## Bugfixes
- Handles newlines when used as separators within a WDL array; outputs a warning that a literal newline was present and adjusts the command to escape the backslash and allow WDL to interpret the newline character.