### PR TITLE
Feature/task-and-output-test-coverage

### DIFF
--- a/src/wdlci/cli/__main__.py
+++ b/src/wdlci/cli/__main__.py
@@ -5,6 +5,9 @@ from wdlci.cli.detect_changes import detect_changes_handler
 from wdlci.cli.submit import submit_handler
 from wdlci.cli.monitor import monitor_handler
 from wdlci.cli.cleanup import cleanup_handler
+from wdlci.cli.detect_task_and_output_coverage import (
+    detect_task_and_output_coverage_handler,
+)
 from wdlci.utils.ordered_group import OrderedGroup
 
 remove_option = click.option(
@@ -100,3 +103,10 @@ def cleanup(**kwargs):
     """Clean Workbench namespace of transient artifacts"""
 
     cleanup_handler(kwargs)
+
+
+@main.command
+def detect_task_and_output_coverage(**kwargs):
+    """Outputs how much coverage each task and output has, and which tasks/outputs have no associated tests"""
+
+    detect_task_and_output_coverage_handler(kwargs)

--- a/src/wdlci/cli/detect_changes.py
+++ b/src/wdlci/cli/detect_changes.py
@@ -24,9 +24,6 @@ def detect_changes_handler(kwargs):
                 task_name = task.name
                 task_digest = task.digest
 
-                if not workflow_config.tasks[task_name].tests:
-                    tasks_without_tests.append(task_name)
-
                 if task_name in workflow_config.tasks:
                     previous_digest = workflow_config.tasks[task_name].digest
                     if (
@@ -40,7 +37,6 @@ def detect_changes_handler(kwargs):
                     print(f"New task detected [{workflow} - {task_name}]")
                     workflow_change = changeset.add_workflow_change(workflow)
                     workflow_change.add_task_change(task_name)
-        print(f"The following tasks have no tests: {', '.join(tasks_without_tests)}")
 
         if len(changeset.workflow_changes) == 0:
             print("No new or modified tasks detected")

--- a/src/wdlci/cli/detect_task_and_output_coverage.py
+++ b/src/wdlci/cli/detect_task_and_output_coverage.py
@@ -21,31 +21,26 @@ def detect_task_and_output_coverage_handler(kwargs):
 
             for task in doc.tasks:
                 task_name = task.name
-
                 # task_test_configs is a list of WorkflowTaskTestConfig objects,
                 # which contain inputs and output_tests as attributes
                 task_test_configs = workflow_config.tasks[task_name].tests
+
                 if not task_test_configs:
                     tasks_without_tests.append(task_name)
 
                 task_coverage_count = 0
 
                 for task_test_config in task_test_configs:
-                    # Create a dictionary of output tests
                     output_tests_dict = task_test_config.output_tests
-                    # Also created a nested dictionary of output coverage, which will
-                    # store a task name as the parent key
                     output_coverage[task_name] = {}
-                    # For each key and value in a given output test dict
+
                     for output_key, output_value in output_tests_dict.items():
-                        # Ensure output value is a dict with the key test_tasks present
                         if (
                             isinstance(output_value, dict)
                             and "test_tasks" in output_value
                         ):
-                            # Create a list of test tasks for each output
                             output_tests_list = output_value["test_tasks"]
-                            # Assign the number of test tasks to the key associated with a
+                            # Assign the length of test tasks to the key associated with a
                             # given output in a nested structure, where each task has a
                             # dictionary of outputs and their task counts
                             output_coverage[task_name][output_key] = len(
@@ -53,8 +48,9 @@ def detect_task_and_output_coverage_handler(kwargs):
                             )
                             task_coverage_count += len(output_tests_list)
 
-                            if len(output_tests_list) == 0:
+                            if not output_tests_list:
                                 outputs_without_tests.append(output_key)
+
                     task_coverage[task_name] = task_coverage_count
 
         print("Task Coverage:")

--- a/src/wdlci/cli/detect_task_and_output_coverage.py
+++ b/src/wdlci/cli/detect_task_and_output_coverage.py
@@ -25,8 +25,6 @@ def detect_task_and_output_coverage_handler(kwargs):
                 # task_test_configs is a list of WorkflowTaskTestConfig objects,
                 # which contain inputs and output_tests as attributes
                 task_test_configs = workflow_config.tasks[task_name].tests
-                # TODO: this is actually telling us which WORKFLOWS don't have any tests,
-                # once I test with a larger wf, this may need to be adjusted
                 if not task_test_configs:
                     tasks_without_tests.append(task_name)
 
@@ -73,16 +71,16 @@ def detect_task_and_output_coverage_handler(kwargs):
 
         if tasks_without_tests and outputs_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests: {', '.join(tasks_without_tests)}"
-                + f" and the following outputs have no tests: {', '.join(outputs_without_tests)}.\n"
+                f"\nWARNING: The following tasks have no tests:\n\n{', '.join(tasks_without_tests)}\n\n"
+                + f"Additionally, the following outputs have no tests:\n\n{', '.join(outputs_without_tests)}\n\n"
             )
         elif tasks_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests: {', '.join(tasks_without_tests)}.\n"
+                f"\nWARNING: The following tasks have no tests:\n\n{', '.join(tasks_without_tests)}\n\n"
             )
         elif outputs_without_tests:
             print(
-                f"\nWARNING: The following outputs have no tests: {', '.join(outputs_without_tests)}.\n"
+                f"\nWARNING: The following outputs have no tests:\n\n{', '.join(outputs_without_tests)}\n\n"
             )
 
     except WdlTestCliExitException as e:

--- a/src/wdlci/cli/detect_task_and_output_coverage.py
+++ b/src/wdlci/cli/detect_task_and_output_coverage.py
@@ -1,0 +1,90 @@
+import sys
+import WDL
+from wdlci.config import Config
+from wdlci.config.config_file import WorkflowTaskConfig, WorkflowTaskTestConfig
+from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
+
+
+def detect_task_and_output_coverage_handler(kwargs):
+    try:
+        Config.load(kwargs)
+        config = Config.instance()
+
+        tasks_without_tests = []
+        outputs_without_tests = []
+
+        task_coverage = {}
+        output_coverage = {}
+
+        for workflow, workflow_config in config.file.workflows.items():
+            doc = WDL.load(workflow)
+
+            for task in doc.tasks:
+                task_name = task.name
+
+                # task_test_configs is a list of WorkflowTaskTestConfig objects,
+                # which contain inputs and output_tests as attributes
+                task_test_configs = workflow_config.tasks[task_name].tests
+                # TODO: this is actually telling us which WORKFLOWS don't have any tests,
+                # once I test with a larger wf, this may need to be adjusted
+                if not task_test_configs:
+                    tasks_without_tests.append(task_name)
+
+                task_coverage_count = 0
+
+                for task_test_config in task_test_configs:
+                    # Create a dictionary of output tests
+                    output_tests_dict = task_test_config.output_tests
+                    # Also created a nested dictionary of output coverage, which will
+                    # store a task name as the parent key
+                    output_coverage[task_name] = {}
+                    # For each key and value in a given output test dict
+                    for output_key, output_value in output_tests_dict.items():
+                        # Ensure output value is a dict with the key test_tasks present
+                        if (
+                            isinstance(output_value, dict)
+                            and "test_tasks" in output_value
+                        ):
+                            # Create a list of test tasks for each output
+                            output_tests_list = output_value["test_tasks"]
+                            # Assign the number of test tasks to the key associated with a
+                            # given output in a nested structure, where each task has a
+                            # dictionary of outputs and their task counts
+                            output_coverage[task_name][output_key] = len(
+                                output_tests_list
+                            )
+                            task_coverage_count += len(output_tests_list)
+
+                            if len(output_tests_list) == 0:
+                                outputs_without_tests.append(output_key)
+                    task_coverage[task_name] = task_coverage_count
+
+        print("Task Coverage:")
+        for task_name, tests_count in task_coverage.items():
+            print(f"\t{task_name}: {tests_count}\n")
+
+        print("Output coverage:")
+        for task_name, output_tests_dict in output_coverage.items():
+            print(f"\tTask name: {task_name}")
+            for output_name, tests_count in output_tests_dict.items():
+                print(
+                    f"\t\tOutput name: {output_name}\n\t\t\tnumber of tests: {tests_count}"
+                )
+
+        if tasks_without_tests and outputs_without_tests:
+            print(
+                f"\nWARNING: The following tasks have no tests: {', '.join(tasks_without_tests)}"
+                + f" and the following outputs have no tests: {', '.join(outputs_without_tests)}.\n"
+            )
+        elif tasks_without_tests:
+            print(
+                f"\nWARNING: The following tasks have no tests: {', '.join(tasks_without_tests)}.\n"
+            )
+        elif outputs_without_tests:
+            print(
+                f"\nWARNING: The following outputs have no tests: {', '.join(outputs_without_tests)}.\n"
+            )
+
+    except WdlTestCliExitException as e:
+        print(f"exiting with code {e.exit_code}, message: {e.message}")
+        sys.exit(e.exit_code)

--- a/src/wdlci/cli/detect_task_and_output_coverage.py
+++ b/src/wdlci/cli/detect_task_and_output_coverage.py
@@ -55,9 +55,9 @@ def detect_task_and_output_coverage_handler(kwargs):
 
         print("Task Coverage:")
         for task_name, tests_count in task_coverage.items():
-            print(f"\t{task_name}: {tests_count}\n")
+            print(f"\t{task_name}: {tests_count}")
 
-        print("Output coverage:")
+        print("\nOutput coverage:")
         for task_name, output_tests_dict in output_coverage.items():
             print(f"\tTask name: {task_name}")
             for output_name, tests_count in output_tests_dict.items():
@@ -67,16 +67,16 @@ def detect_task_and_output_coverage_handler(kwargs):
 
         if tasks_without_tests and outputs_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests:\n\n{', '.join(tasks_without_tests)}\n\n"
-                + f"Additionally, the following outputs have no tests:\n\n{', '.join(outputs_without_tests)}\n\n"
+                f"\nWARNING: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
+                + f"Additionally, the following outputs have no tests:\n{', '.join(outputs_without_tests)}\n\n"
             )
         elif tasks_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests:\n\n{', '.join(tasks_without_tests)}\n\n"
+                f"\nWARNING: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
             )
         elif outputs_without_tests:
             print(
-                f"\nWARNING: The following outputs have no tests:\n\n{', '.join(outputs_without_tests)}\n\n"
+                f"\nWARNING: The following outputs have no tests:\n{', '.join(outputs_without_tests)}\n\n"
             )
 
     except WdlTestCliExitException as e:

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -247,6 +247,34 @@ def _write_task(doc_task, output_file):
 
         ## Command
         f.write("\tcommand <<<\n")
+        original_command = str(doc_task.command)
+
+        # Use a generator expression to iterate over doc_task.command children and
+        # check if any contain newline characters and a specified separator and
+        # ensure the separator precedes '\n'
+        newline_children = [
+            c
+            for c in doc_task.command.children
+            if "\n" in str(c)
+            and "sep=" in str(c)
+            and str(c).index("sep=") < str(c).index("\n")
+        ]
+        if newline_children:
+            for child in newline_children:
+                print(
+                    "\nWarning: it looks like a literal newline was present as a separator in "
+                    "your command and may need to be escaped."
+                )
+                child_str = str(child).replace("\n", "\\n")
+                modified_command = original_command.replace(str(child), child_str)
+                print(
+                    "The literal newline was escaped and replaced with the literal '\\n' as:\n "
+                    f"{modified_command}\nIf this is not intended, escape the newline character in "
+                    "your workflow manually.\n"
+                )
+                f.write(f"\t\t{modified_command}\n")
+        else:
+            f.write(f"\t\t{original_command}\n")
         f.write(f"\t\t{doc_task.command}\n")
         f.write("\t>>>\n")
         f.write("\n")

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -248,10 +248,8 @@ def _write_task(doc_task, output_file):
         ## Command
         f.write("\tcommand <<<\n")
         original_command = str(doc_task.command)
-
-        # Use a generator expression to iterate over doc_task.command children and
-        # check if any contain newline characters and a specified separator and
-        # ensure the separator precedes '\n'
+        # Create list of task children and check if there is an instance
+        # of a newline character being used as a separator that will be interpreted literally
         newline_children = [
             c
             for c in doc_task.command.children
@@ -265,8 +263,8 @@ def _write_task(doc_task, output_file):
                     "\nWarning: it looks like a literal newline was present as a separator in "
                     "your command and may need to be escaped."
                 )
-                child_str = str(child).replace("\n", "\\n")
-                modified_command = original_command.replace(str(child), child_str)
+                modified_child = str(child).replace("\n", "\\n")
+                modified_command = original_command.replace(str(child), modified_child)
                 print(
                     "The literal newline was escaped and replaced with the literal '\\n' as:\n "
                     f"{modified_command}\nIf this is not intended, escape the newline character in "

--- a/src/wdlci/wdl_tests/check_zip.wdl
+++ b/src/wdlci/wdl_tests/check_zip.wdl
@@ -1,0 +1,47 @@
+version 1.0
+
+# Check integrity of ZIP file
+# Input type: ZIP file
+
+task check_zip {
+	input {
+		File current_run_output
+		File validated_output
+	}
+
+	Int disk_size = ceil(size(current_run_output, "GB") + size(validated_output, "GB") + 50)
+
+	command <<<
+		set -euo pipefail
+
+		err() {
+			message=$1
+
+			echo -e "[ERROR] $message" >&2
+		}
+
+		if ! zip -T ~{validated_output}; then
+			err "Validated file: [~{basename(validated_output)}] did not pass zip check"
+			exit 1
+		else
+			if ! zip -T ~{current_run_output}; then
+				err "Current run file: [~{basename(current_run_output)}] did not pass zip check"
+				exit 1
+			else
+				echo "Current run file: [~{basename(current_run_output)}] passed zip check"
+			fi
+		fi
+	>>>
+
+	output {
+	}
+
+	runtime {
+		docker: "dnastack/dnastack-wdl-ci-tools:0.0.1"
+		cpu: 1
+		memory: "3.75 GB"
+		disk: disk_size + " GB"
+		disks: "local-disk " + disk_size + " HDD"
+		preemptible: 1
+	}
+}


### PR DESCRIPTION
## Features
- Adds a command to the CLI that tells the user the number of tests associated with a given task as well as a given output. If there are any tasks or outputs with no tests, a warning is printed listing the relevant tasks/outputs. 