### PR TITLE
Feature/handle-output-key-error

### DIFF
--- a/src/wdlci/cli/detect_task_and_output_coverage.py
+++ b/src/wdlci/cli/detect_task_and_output_coverage.py
@@ -67,16 +67,16 @@ def detect_task_and_output_coverage_handler(kwargs):
 
         if tasks_without_tests and outputs_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
+                f"\n[WARN]: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
                 + f"Additionally, the following outputs have no tests:\n{', '.join(outputs_without_tests)}\n\n"
             )
         elif tasks_without_tests:
             print(
-                f"\nWARNING: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
+                f"\n[WARN]: The following tasks have no tests:\n{', '.join(tasks_without_tests)}\n\n"
             )
         elif outputs_without_tests:
             print(
-                f"\nWARNING: The following outputs have no tests:\n{', '.join(outputs_without_tests)}\n\n"
+                f"\n[WARN]: The following outputs have no tests:\n{', '.join(outputs_without_tests)}\n\n"
             )
 
     except WdlTestCliExitException as e:

--- a/src/wdlci/cli/submit.py
+++ b/src/wdlci/cli/submit.py
@@ -82,14 +82,14 @@ def submit_handler(kwargs):
                     # Register and create workflows for all tasks with tests
                     for test_index, test_input_set in enumerate(task.tests):
                         doc_main_task = doc_tasks[task_key]
-
+                        # Create list of workflow output names
                         for output in doc_main_task.outputs:
                             match = output_file_name_pattern.search(str(output))
                             if match:
                                 workflow_outputs.extend([match.group(1)])
 
                         output_tests = test_input_set.output_tests
-
+                        # Create dictionary of missing outputs
                         missing_outputs_dict = {
                             key: output_tests[key]
                             for key in output_tests

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -7,6 +7,7 @@ from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
 from wdlci.config import Config
 from wdlci.config.config_file import WorkflowTaskConfig, WorkflowTaskTestConfig
 
+
 def _order_structs(struct_typedefs):
     """
     Order struct_typedefs such that structs that are dependencies of other structs are written first
@@ -135,16 +136,19 @@ def write_workflow(
             f.write(f"\t\t{task_input}\n")
         f.write("\n")
 
-        filtered_output_tests = {key: output_tests[key] for key in output_tests if key in all_outputs}
+        filtered_output_tests = {
+            key: output_tests[key] for key in output_tests if key in all_outputs
+        }
 
         for output_key in output_tests.keys():
             if output_key not in filtered_output_tests.keys():
                 raise WdlTestCliExitException(
-                    f"Expected output {output_key} not found in task {main_task.name}; has this output been removed?\nIf so, you >
+                    f"Expected output {output_key} not found in task {main_task.name}; has this output been removed?\nIf so, you ill need to remove this output from the wdl-ci.config.json before proceeding.",
+                    1,
                 )
         # This is just a catch for now; can likely be removed once testing has been completed.
         for output_key in filtered_output_tests.keys():
-            print (f"{output_key} found in wdl-ci.config.json and {main_task.name}.")
+            print(f"{output_key} found in wdl-ci.config.json and {main_task.name}.")
 
         for output_key in output_tests:
             test_output_type = _get_output_type(main_task_output_types, output_key)

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 from importlib.resources import files
 from wdlci.exception.wdl_test_cli_exit_exception import WdlTestCliExitException
+from wdlci.config.config_file import WorkflowTaskConfig, WorkflowTaskTestConfig
 
 
 def _order_structs(struct_typedefs):
@@ -117,6 +118,10 @@ def write_workflow(
         for task_input in main_task.inputs:
             f.write(f"\t\t{task_input}\n")
         f.write("\n")
+
+        ## TODO
+        # Issue: When removing an output from a task, if the wdl-ci.config.json file is not also updated to remove that output, the github action will fail with a KeyError when it tries to write the workflow for that changed task.
+        # Fix: We should check the config file and the outputs from the updated task and compare them, outputting a more useful error like "Expected output <> not found in task <>; has this output been removed?" and/or advice to remove this output from the wdl-ci.config.json.
 
         for output_key in output_tests:
             test_output_type = _get_output_type(main_task_output_types, output_key)

--- a/src/wdlci/utils/write_workflow.py
+++ b/src/wdlci/utils/write_workflow.py
@@ -108,11 +108,12 @@ def write_workflow(
         doc = WDL.load(workflow)
         for task in doc.tasks:
             task_outputs = task.outputs
-            all_outputs = [
+            outputs = [
                 match.group(1)
                 for output in task_outputs
                 if (match := output_file_name_pattern.search(str(output)))
             ]
+            all_outputs.extend(outputs)
 
     # Create a dictionary of outputs absent from the workflow but present in the config JSON
     missing_outputs_dict = {


### PR DESCRIPTION
## Features
- Output a better error message when an output key is not found. Instead of getting a KeyError when an output is removed from a workflow but not the `wdl-ci.config.json`, a list of all outputs from a given workflow is created. From that list, a dictionary is created that stores any tasks present in the JSON file but **not** in the workflow. If the dictionary is not empty, each key is appended to a list and reported back to the user alongside a raised `WdlTestCliExitException`.