### PR TITLE
Upgrade shellcheck to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,14 @@ FROM python:3.11.0-slim-buster
 RUN apt-get -qq update \
 	&& apt-get -qq install \
 		git \
-		shellcheck \
+		wget \
+		xz-utils \
 		gcc
+
+# Shellcheck
+ENV SHELLCHECK_VERSION=v0.10.0
+RUN wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv --directory /opt
+ENV PATH="${PATH}:/opt/shellcheck-${SHELLCHECK_VERSION}"
 
 WORKDIR /usr/src
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If any step of the action fails, the check will fail; however if some task tests
 # GitHub action usage
 
 ```yaml
-- uses: dnastack/wdl-ci@v2.0.1
+- uses: dnastack/wdl-ci@v2.0.2
   with:
     # Configuration file where tests can be found
     # Default: wdl-ci.config.json
@@ -91,7 +91,7 @@ jobs:
         with:
           submodules: true
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.1
+        uses: dnastack/wdl-ci@v2.0.2
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -119,7 +119,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.1
+        uses: dnastack/wdl-ci@v2.0.2
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -149,7 +149,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.1
+        uses: dnastack/wdl-ci@v2.0.2
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -53,19 +53,19 @@ runs:
           echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl-ci-custom-test-wdl-dir }} >> $GITHUB_ENV
         fi
     - name: lint
-      uses: docker://dnastack/wdl-ci:v2.0.1
+      uses: docker://dnastack/wdl-ci:v2.0.2
       with:
         args: lint ${{ inputs.suppress-lint-errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
-      uses: docker://dnastack/wdl-ci:v2.0.1
+      uses: docker://dnastack/wdl-ci:v2.0.2
       with:
         args: detect-changes
     - name: submit
-      uses: docker://dnastack/wdl-ci:v2.0.1
+      uses: docker://dnastack/wdl-ci:v2.0.2
       with:
         args: submit
     - name: monitor
-      uses: docker://dnastack/wdl-ci:v2.0.1
+      uses: docker://dnastack/wdl-ci:v2.0.2
       with:
         args: monitor --update-digests
       # If a test fails, still update task digests for any tests that succeeded
@@ -79,6 +79,6 @@ runs:
         default_author: github_actions
     - name: cleanup
       if: always()
-      uses: docker://dnastack/wdl-ci:v2.0.1
+      uses: docker://dnastack/wdl-ci:v2.0.2
       with:
         args: cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wdl-testing-cli"
 description = "DNAstack WDL testing CLI"
-version = "2.0.1"
+version = "2.0.2"
 authors = [
     { name = "DNAstack", email = "devs@dnastack.com" }
 ]


### PR DESCRIPTION
This will avoid marking deprecated lints as issues