### PR TITLE
Do not fetch when committing updated wdl ci config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If any step of the action fails, the check will fail; however if some task tests
 # GitHub action usage
 
 ```yaml
-- uses: dnastack/wdl-ci@v2.0.2
+- uses: dnastack/wdl-ci@v2.0.3
   with:
     # Configuration file where tests can be found
     # Default: wdl-ci.config.json
@@ -87,11 +87,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.2
+        uses: dnastack/wdl-ci@v2.0.3
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -113,13 +113,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.2
+        uses: dnastack/wdl-ci@v2.0.3
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -143,13 +143,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.0.2
+        uses: dnastack/wdl-ci@v2.0.3
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -53,19 +53,19 @@ runs:
           echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl-ci-custom-test-wdl-dir }} >> $GITHUB_ENV
         fi
     - name: lint
-      uses: docker://dnastack/wdl-ci:v2.0.2
+      uses: docker://dnastack/wdl-ci:v2.0.3
       with:
         args: lint ${{ inputs.suppress-lint-errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
-      uses: docker://dnastack/wdl-ci:v2.0.2
+      uses: docker://dnastack/wdl-ci:v2.0.3
       with:
         args: detect-changes
     - name: submit
-      uses: docker://dnastack/wdl-ci:v2.0.2
+      uses: docker://dnastack/wdl-ci:v2.0.3
       with:
         args: submit
     - name: monitor
-      uses: docker://dnastack/wdl-ci:v2.0.2
+      uses: docker://dnastack/wdl-ci:v2.0.3
       with:
         args: monitor --update-digests
       # If a test fails, still update task digests for any tests that succeeded
@@ -80,6 +80,6 @@ runs:
         fetch: false
     - name: cleanup
       if: always()
-      uses: docker://dnastack/wdl-ci:v2.0.2
+      uses: docker://dnastack/wdl-ci:v2.0.3
       with:
         args: cleanup

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,7 @@ runs:
         add: ${{ inputs.config-file }}
         message: "update wdl-ci config file after successful tests"
         default_author: github_actions
+        fetch: false
     - name: cleanup
       if: always()
       uses: docker://dnastack/wdl-ci:v2.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wdl-testing-cli"
 description = "DNAstack WDL testing CLI"
-version = "2.0.2"
+version = "2.0.3"
 authors = [
     { name = "DNAstack", email = "devs@dnastack.com" }
 ]


### PR DESCRIPTION
This appears to be causing issues with submodules losing refs, and _shouldn't_ be necessary for committing the updated file.