### PR TITLE
Add -q flag to gzip -t command

### DIFF
--- a/src/wdlci/wdl_tests/check_comma_separated.wdl
+++ b/src/wdlci/wdl_tests/check_comma_separated.wdl
@@ -20,7 +20,7 @@ task check_comma_separated {
 			echo -e "[ERROR] $message" >&2
 		}
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			gzip -d -f ~{current_run_output} ~{validated_output}
 		fi
 

--- a/src/wdlci/wdl_tests/check_empty_lines.wdl
+++ b/src/wdlci/wdl_tests/check_empty_lines.wdl
@@ -20,7 +20,7 @@ task check_empty_lines {
 			echo -e "[ERROR] $message" >&2
 		}
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			current_run_output_empty_lines_count=$(zgrep -c "^$" ~{current_run_output} || [[ $? == 1 ]])
 			validated_output_empty_lines_count=$(zgrep -c "^$" ~{validated_output} || [[ $? == 1 ]])
 		else

--- a/src/wdlci/wdl_tests/check_json.wdl
+++ b/src/wdlci/wdl_tests/check_json.wdl
@@ -20,7 +20,7 @@ task check_json {
 			echo -e "[ERROR] $message" >&2
 		}
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			gzip -d -f ~{current_run_output} ~{validated_output}
 		fi
 

--- a/src/wdlci/wdl_tests/check_tab_delimited.wdl
+++ b/src/wdlci/wdl_tests/check_tab_delimited.wdl
@@ -20,7 +20,7 @@ task check_tab_delimited {
 			echo -e "[ERROR] $message" >&2
 		}
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			gzip -d -f ~{current_run_output} ~{validated_output}
 		fi
 

--- a/src/wdlci/wdl_tests/count_bed_columns.wdl
+++ b/src/wdlci/wdl_tests/count_bed_columns.wdl
@@ -24,7 +24,7 @@ task count_bed_columns {
 		validated_dir_path=$(dirname ~{validated_output})
 		current_dir_path=$(dirname ~{current_run_output})
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			gzip -d -f ~{current_run_output} ~{validated_output}
 			# Assuming header does not start with chr...
 			current_run_output_column_count=$(sed '/^chr/!d' "${current_dir_path}/$(basename ~{current_run_output} .gz)" | awk '{print NF}' | sort -nu | tail -n 1)

--- a/src/wdlci/wdl_tests/count_columns.wdl
+++ b/src/wdlci/wdl_tests/count_columns.wdl
@@ -23,7 +23,7 @@ task count_columns {
 		current=~{current_run_output}
 		validated=~{validated_output}
 
-		if gzip -t ~{current_run_output}; then
+		if gzip -tq ~{current_run_output}; then
 			gzip -d -f ~{current_run_output} ~{validated_output}
 			current=$(dirname ~{current_run_output})/$(basename ~{current_run_output} .gz)
 			validated=$(dirname ~{validated_output})/$(basename ~{validated_output} .gz)


### PR DESCRIPTION
This avoids stderr messages warning that the file is not gzipped which may be confusing when these tests are passed an uncompressed file. If the input file is gzip-compressed, it will still be decompressed.