### PR TITLE
Add PR CI, version-bump script, and dev/release docs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,40 @@
+name: PR checks
+run-name: PR checks
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+jobs:
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: install tools
+        run: python -m pip install black pytest
+      - name: check formatting
+        run: black --check src scripts tests
+      - name: check version consistency
+        run: python scripts/bump_version.py --check
+      - name: run unit tests
+        run: python -m pytest tests/unit -v
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: build image
+        run: docker build -t wdl-ci:ci .
+      - name: cli starts
+        run: |
+          docker run --rm wdl-ci:ci --version
+          docker run --rm wdl-ci:ci --help
+      - name: smoke generate-config and lint on fixture
+        run: |
+          docker run --rm -v "${{ github.workspace }}/tests/fixtures:/usr/test" wdl-ci:ci generate-config
+          docker run --rm -v "${{ github.workspace }}/tests/fixtures:/usr/test" wdl-ci:ci lint --suppress-lint-errors

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: install tools
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build image
         run: docker build -t wdl-ci:ci .
       - name: cli starts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to wdl-ci
+
+## Development
+
+`wdl-ci` is a Python CLI (entry point `wdl-ci`) that is published as the Docker image `dnastack/wdl-ci`. The GitHub Action defined in `action.yml` runs that image.
+
+### Local setup
+
+1. Create and activate a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`
+2. Install the package in editable mode: `python3 -m pip install -e .`
+3. Install [shellcheck](https://github.com/koalaman/shellcheck) (required by `miniwdl check`, which `wdl-ci lint` calls). On macOS: `brew install shellcheck`; on Debian/Ubuntu: `apt-get install shellcheck`.
+4. Install the dev tools used by CI: `python3 -m pip install black pytest`
+
+### Formatting and tests
+
+- Format code before committing: `black src scripts tests`
+- Run the unit tests: `python3 -m pytest tests/unit -v`
+
+### Running the smoke test locally
+
+This is the same check CI runs, and it is the quickest way to validate a dependency bump (for example a Renovate PR) before merging:
+
+```bash
+docker build -t wdl-ci:ci .
+docker run --rm wdl-ci:ci --version
+docker run --rm -v "$PWD/tests/fixtures:/usr/test" wdl-ci:ci generate-config
+docker run --rm -v "$PWD/tests/fixtures:/usr/test" wdl-ci:ci lint --suppress-lint-errors
+```
+
+If the image builds and all four commands exit 0, the tool still installs and runs.
+
+## How CI works
+
+The `.github/workflows/pr-checks.yml` workflow runs on every PR to `main` and on pushes to `main`. It has two jobs:
+
+- `static-checks`: runs `black --check`, verifies the version is consistent across files (`python scripts/bump_version.py --check`), and runs the unit tests.
+- `docker-smoke`: builds the Docker image and runs `wdl-ci --version`, `--help`, then `generate-config` and `lint` against `tests/fixtures/hello.wdl`. This catches broken Dockerfiles, base-image breakage, dependency install failures, import errors, and WDL-parsing regressions without needing any Workbench credentials.
+
+CI does NOT run the Workbench integration steps (`submit`, `monitor`, `cleanup`) on PRs, because those require live infrastructure and secrets. Those are exercised only when the action runs for real against a workflow repository.
+
+For Renovate automerge to wait on these checks, both `static-checks` and `docker-smoke` must be required status checks on `main`. Set this under repository Settings -> Branches -> Branch protection rules for `main` -> "Require status checks to pass before merging", and select `static-checks` and `docker-smoke`.
+
+## Releasing
+
+The version string lives in three files: `pyproject.toml` (`version`), `action.yml` (the `docker://dnastack/wdl-ci:vX.Y.Z` references), and the usage example in `README.md`. GitHub Actions cannot read a variable into a `uses:` line, so these cannot share a single source; instead, `scripts/bump_version.py` updates all of them at once and CI verifies they stay in sync.
+
+To cut a release:
+
+1. Bump the version everywhere: `python scripts/bump_version.py X.Y.Z`
+2. Commit the change and merge it to `main`.
+3. Tag the merge commit and push the tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. Publish a GitHub Release for that tag (Releases -> Draft a new release -> choose the `vX.Y.Z` tag). Publishing triggers `.github/workflows/docker-build-push.yml`.
+5. That workflow checks out the tag, runs `git describe --tags --abbrev=0` to read the version, builds the image, and pushes `dnastack/wdl-ci:vX.Y.Z`, `dnastack/wdl-ci:latest`, and a long-SHA tag to Docker Hub.
+6. Verify the image appears on Docker Hub and that `action.yml` references the new tag.
+
+Why the version in `action.yml` must be bumped in lockstep: the Action pulls `docker://dnastack/wdl-ci:vX.Y.Z` literally. If you tag a new version but leave `action.yml` pointing at the old one, the Action keeps running the previous image. The `bump_version.py --check` CI guard makes a partial bump fail the PR rather than ship silently.
+
+### A note on dependency pinning
+
+Renovate pins third-party GitHub Actions to commit SHAs and the Docker base image to a digest (a supply-chain best practice). It is configured NOT to manage the `dnastack/wdl-ci` self-image, because pinning our own image by digest would create a circular dependency (the digest only exists after the release is built) for no security benefit. The self-image version is owned by the release process above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ docker run --rm -v "$PWD/tests/fixtures:/usr/test" wdl-ci:ci lint --suppress-lin
 
 If the image builds and all four commands exit 0, the tool still installs and runs.
 
+The `generate-config` step writes `tests/fixtures/wdl-ci.config.json` into the mounted directory, owned by root because the container runs as root. Remove it afterward with `sudo rm -f tests/fixtures/wdl-ci.config.json` so it does not linger in your working tree.
+
 ## How CI works
 
 The `.github/workflows/pr-checks.yml` workflow runs on every PR to `main` and on pushes to `main`. It has two jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.0-slim-buster
+FROM python:3.11-slim-bookworm
 
 RUN apt-get -qq update \
 	&& apt-get -qq install \

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
   "commitMessagePrefix": "[CU-86b4umhm1]",
   "packageRules": [
     {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["dnastack/wdl-ci"],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["Major"]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -71,7 +71,6 @@ if __name__ == "__main__":
         "-v",
         "--version",
         type=str,
-        required=False,
         help="New version to set, e.g. 2.2.0 (no 'v' prefix)",
     )
     group.add_argument(

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,86 @@
+import argparse
+import logging
+import re
+import sys
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+SEMVER = r"\d+\.\d+\.\d+"
+
+# Files that carry the wdl-ci version. Each regex's full match is the bare X.Y.Z
+# version; lookarounds anchor it to the surrounding literal so we never touch
+# unrelated version-like strings such as SHA-pinned third-party actions.
+VERSION_LOCATIONS = [
+    (
+        "pyproject.toml",
+        re.compile(r'(?<=^version = ")' + SEMVER + r'(?=")', re.MULTILINE),
+    ),
+    ("action.yml", re.compile(r"(?<=docker://dnastack/wdl-ci:v)" + SEMVER)),
+    ("README.md", re.compile(r"(?<=dnastack/wdl-ci@v)" + SEMVER)),
+]
+
+
+def bump(version):
+    for path, pattern in VERSION_LOCATIONS:
+        with open(path, "r") as handle:
+            text = handle.read()
+        new_text, count = pattern.subn(version, text)
+        if count == 0:
+            logger.error("No version reference found in %s", path)
+            return 1
+        with open(path, "w") as handle:
+            handle.write(new_text)
+        logger.info("Updated %d reference(s) in %s -> %s", count, path, version)
+    return 0
+
+
+def check():
+    found = {}
+    for path, pattern in VERSION_LOCATIONS:
+        with open(path, "r") as handle:
+            text = handle.read()
+        matches = set(pattern.findall(text))
+        if not matches:
+            logger.error("No version reference found in %s", path)
+            return 1
+        if len(matches) > 1:
+            logger.error("Inconsistent versions within %s: %s", path, sorted(matches))
+            return 1
+        found[path] = matches.pop()
+    unique = set(found.values())
+    if len(unique) > 1:
+        logger.error("Version mismatch across files: %s", found)
+        return 1
+    logger.info("Version is consistent across all files: %s", unique.pop())
+    return 0
+
+
+def main(args):
+    if args.check:
+        return check()
+    return bump(args.version)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Bump or verify the wdl-ci version across project files."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "-v",
+        "--version",
+        type=str,
+        required=False,
+        help="New version to set, e.g. 2.2.0 (no 'v' prefix)",
+    )
+    group.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        help="Verify the version is consistent across all files",
+    )
+    parsed_args = parser.parse_args()
+    if parsed_args.version and not re.fullmatch(SEMVER, parsed_args.version):
+        parser.error("version must look like X.Y.Z")
+    sys.exit(main(parsed_args))

--- a/tests/fixtures/hello.wdl
+++ b/tests/fixtures/hello.wdl
@@ -1,0 +1,35 @@
+version 1.0
+
+workflow hello {
+    input {
+        String name = "world"
+    }
+
+    call say_hello {
+        input:
+            name = name
+    }
+
+    output {
+        File greeting = say_hello.greeting
+    }
+}
+
+task say_hello {
+    input {
+        String name
+    }
+
+    command <<<
+        set -euo pipefail
+        echo "Hello, ~{name}!" > greeting.txt
+    >>>
+
+    output {
+        File greeting = "greeting.txt"
+    }
+
+    runtime {
+        docker: "ubuntu:22.04"
+    }
+}

--- a/tests/unit/test_bump_version.py
+++ b/tests/unit/test_bump_version.py
@@ -36,7 +36,7 @@ def test_bump_leaves_third_party_pinned_actions_untouched(tmp_path, monkeypatch)
     _write_project(tmp_path, "2.1.0")
     monkeypatch.chdir(tmp_path)
 
-    bump_version.bump("2.2.0")
+    assert bump_version.bump("2.2.0") == 0
 
     assert "actions/checkout@abc123 # v4" in (tmp_path / "action.yml").read_text()
 
@@ -54,3 +54,14 @@ def test_check_returns_nonzero_when_versions_differ(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     assert bump_version.check() == 1
+
+
+def test_bump_returns_nonzero_when_no_version_reference_found(tmp_path, monkeypatch):
+    _write_project(tmp_path, "2.1.0")
+    # Replace action.yml with content that has no docker://dnastack/wdl-ci:v reference
+    (tmp_path / "action.yml").write_text(
+        "runs:\n  steps:\n    - uses: actions/checkout@abc123 # v4\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert bump_version.bump("2.2.0") == 1

--- a/tests/unit/test_bump_version.py
+++ b/tests/unit/test_bump_version.py
@@ -1,0 +1,56 @@
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "bump_version.py"
+spec = importlib.util.spec_from_file_location("bump_version", SCRIPT)
+bump_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bump_version)
+
+
+def _write_project(root, version):
+    (root / "pyproject.toml").write_text(f'[project]\nversion = "{version}"\n')
+    (root / "action.yml").write_text(
+        "runs:\n"
+        "  steps:\n"
+        f"    - uses: docker://dnastack/wdl-ci:v{version}\n"
+        f"    - uses: docker://dnastack/wdl-ci:v{version}\n"
+        "    - uses: actions/checkout@abc123 # v4\n"
+    )
+    (root / "README.md").write_text(f"- uses: dnastack/wdl-ci@v{version}\n")
+
+
+def test_bump_updates_version_in_all_three_files(tmp_path, monkeypatch):
+    _write_project(tmp_path, "2.1.0")
+    monkeypatch.chdir(tmp_path)
+
+    assert bump_version.bump("2.2.0") == 0
+
+    assert 'version = "2.2.0"' in (tmp_path / "pyproject.toml").read_text()
+    action = (tmp_path / "action.yml").read_text()
+    assert "docker://dnastack/wdl-ci:v2.2.0" in action
+    assert "docker://dnastack/wdl-ci:v2.1.0" not in action
+    assert "dnastack/wdl-ci@v2.2.0" in (tmp_path / "README.md").read_text()
+
+
+def test_bump_leaves_third_party_pinned_actions_untouched(tmp_path, monkeypatch):
+    _write_project(tmp_path, "2.1.0")
+    monkeypatch.chdir(tmp_path)
+
+    bump_version.bump("2.2.0")
+
+    assert "actions/checkout@abc123 # v4" in (tmp_path / "action.yml").read_text()
+
+
+def test_check_returns_zero_when_versions_match(tmp_path, monkeypatch):
+    _write_project(tmp_path, "2.1.0")
+    monkeypatch.chdir(tmp_path)
+
+    assert bump_version.check() == 0
+
+
+def test_check_returns_nonzero_when_versions_differ(tmp_path, monkeypatch):
+    _write_project(tmp_path, "2.1.0")
+    (tmp_path / "README.md").write_text("- uses: dnastack/wdl-ci@v9.9.9\n")
+    monkeypatch.chdir(tmp_path)
+
+    assert bump_version.check() == 1


### PR DESCRIPTION
## Summary

- **PR CI (`/.github/workflows/pr-checks.yml`)** that runs on PRs to `main`:
  - `static-checks`: `black --check`, version-consistency check (`bump_version.py --check`), and unit tests.
  - `docker-smoke`: builds the Docker image and runs `wdl-ci --version`/`--help`, then `generate-config` + `lint` against a fixture WDL. This gives Renovate dependency-bump PRs a real safety net with no Workbench secrets required.
- **`scripts/bump_version.py`**: one command bumps the version across `pyproject.toml`, `action.yml`, and `README.md` (which must stay in lockstep), plus a `--check` mode wired into CI to fail partial bumps. Unit-tested.
- **Fix EOL base image**: `python:3.11.0-slim-buster` → `python:3.11-slim-bookworm`. Buster is end-of-life and the image could no longer build (`apt-get update` fails with no Release file). The new smoke test caught this.
- **Renovate**: stop managing the `dnastack/wdl-ci` self-image, so it won't try to digest-pin the tool to itself (which would be circular) or "upgrade" us to newer versions of ourselves.
- **`CONTRIBUTING.md`**: documents local development, how CI works, and a repeatable release process (the tag + `git describe` mechanic, and why `action.yml` must be bumped in lockstep).

## Notes for the maintainer

- **Renovate PR #76** bumps the base image to `3.11.4` but stays on Buster, so it does **not** fix the EOL build failure. Recommend closing it in favor of the bookworm change here.
- **Renovate PR #73** (pin-dependencies): keep the third-party action SHA pins and the base-image digest pin (good supply-chain practice), but drop its three `docker://dnastack/wdl-ci:...@sha256:...` self-image digest lines now that Renovate ignores the self-image.
- **Branch protection**: to make Renovate automerge wait on these checks, mark `static-checks` and `docker-smoke` as required status checks on `main` (documented in `CONTRIBUTING.md`).

## Test plan

- [x] `python3 -m pytest tests/unit` — 5 passed
- [x] `black --check src scripts tests` — clean
- [x] `python scripts/bump_version.py --check` — reports 2.1.0 consistent
- [x] `docker build` + smoke (`--version`, `generate-config`, `lint`) pass locally on bookworm
- [ ] Confirm `pr-checks.yml` runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)