### PR TITLE
Release prep v2.2.0

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,7 +20,7 @@ jobs:
           LATEST_TAG="latest"
           ALL_TAGS="${IMAGE}:${VERSION_TAG},${IMAGE}:${LONG_VERSION_TAG},${IMAGE}:${LATEST_TAG}"
 
-          echo ::set-output name=all_tags::${ALL_TAGS}
+          echo "all_tags=${ALL_TAGS}" >> "$GITHUB_OUTPUT"
       - name: set up QEMU
         uses: docker/setup-qemu-action@master
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If any step of the action fails, the check will fail; however if some task tests
 # GitHub action usage
 
 ```yaml
-- uses: dnastack/wdl-ci@v2.1.0
+- uses: dnastack/wdl-ci@v2.2.0
   with:
     # Configuration file where tests can be found
     # Default: wdl-ci.config.json
@@ -91,7 +91,7 @@ jobs:
         with:
           submodules: true
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.1.0
+        uses: dnastack/wdl-ci@v2.2.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -119,7 +119,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.1.0
+        uses: dnastack/wdl-ci@v2.2.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}
@@ -149,7 +149,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: wdl-ci
-        uses: dnastack/wdl-ci@v2.1.0
+        uses: dnastack/wdl-ci@v2.2.0
         with:
           wallet-url: ${{ secrets.WALLET_URL }}
           wallet-client-id: ${{ secrets.WALLET_CLIENT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -53,19 +53,19 @@ runs:
           echo "WDL_CI_CUSTOM_TEST_WDL_DIR"=${{ inputs.wdl-ci-custom-test-wdl-dir }} >> $GITHUB_ENV
         fi
     - name: lint
-      uses: docker://dnastack/wdl-ci:v2.1.0
+      uses: docker://dnastack/wdl-ci:v2.2.0
       with:
         args: lint ${{ inputs.suppress-lint-errors && '--suppress-lint-errors' || '' }}
     - name: detect-changes
-      uses: docker://dnastack/wdl-ci:v2.1.0
+      uses: docker://dnastack/wdl-ci:v2.2.0
       with:
         args: detect-changes
     - name: submit
-      uses: docker://dnastack/wdl-ci:v2.1.0
+      uses: docker://dnastack/wdl-ci:v2.2.0
       with:
         args: submit
     - name: monitor
-      uses: docker://dnastack/wdl-ci:v2.1.0
+      uses: docker://dnastack/wdl-ci:v2.2.0
       with:
         args: monitor --update-digests
       # If a test fails, still update task digests for any tests that succeeded
@@ -80,6 +80,6 @@ runs:
         fetch: false
     - name: cleanup
       if: always()
-      uses: docker://dnastack/wdl-ci:v2.1.0
+      uses: docker://dnastack/wdl-ci:v2.2.0
       with:
         args: cleanup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "wdl-testing-cli"
 description = "DNAstack WDL testing CLI"
-version = "2.1.0"
+version = "2.2.0"
 authors = [
     { name = "DNAstack", email = "devs@dnastack.com" }
 ]


### PR DESCRIPTION
## Summary

Prepares the v2.2.0 release:

- Bumps the version to **2.2.0** across `pyproject.toml`, `action.yml` (5 self-image refs), and `README.md` (usage examples), via `scripts/bump_version.py`.
- Fixes the release workflow: replaces the deprecated `::set-output` command with `$GITHUB_OUTPUT` in `docker-build-push.yml`, so the `prepare tags` step actually passes the image tags to the build-push step.

This release captures everything merged since 2.1.0: Debian bookworm base image, Python 3.14, miniwdl 1.14.2, psutil 7, and the other dependency bumps, plus the new PR CI, version-bump script, and contributor docs.

## Release steps after this merges

1. Tag the merge commit: `git tag v2.2.0 && git push origin v2.2.0`
2. Publish a GitHub Release for `v2.2.0` -> triggers `docker-build-push.yml`, which builds and pushes `dnastack/wdl-ci:v2.2.0`, `:latest`, and a long-SHA tag to Docker Hub.
3. Verify the image on Docker Hub.

## Test plan

- [x] `scripts/bump_version.py --check` reports 2.2.0 consistent across all files
- [x] `static-checks` + `docker-smoke` pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)