### PR TITLE
Drop 32-bit arm/v7 from release build platforms

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,6 +39,6 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ steps.prep.outputs.all_tags }}


### PR DESCRIPTION
## Summary

The release workflow built three platforms: `linux/amd64`, `linux/arm/v7`, and `linux/arm64/v8`. The 32-bit `arm/v7` target is emulated via QEMU and compiles C-extension dependencies (psutil, regex, etc.) from source, which dominated build time (the v2.2.0 release build ran ~30 min, mostly on arm/v7).

This tool is a Docker container action that runs on `amd64` GitHub-hosted runners. The only realistic non-amd64 use is pulling the image locally on Apple Silicon, which is `arm64`. Nobody is plausibly running a cloud-workflow CI tool on 32-bit ARM hardware.

Drop `arm/v7`; keep `linux/amd64,linux/arm64/v8`. Future release builds should drop from ~30 min to a few minutes.

## Notes

- Workflow-only change; no version bump and no change to image contents.
- The two `docker/setup-qemu-action@master` / `setup-buildx-action@master` pins are still untidy but out of scope here.

## Test plan

- [ ] `static-checks` passes (docker-smoke unaffected; it only builds amd64)
- [ ] Effect is validated on the next release build (or a re-release), which should no longer build arm/v7

🤖 Generated with [Claude Code](https://claude.com/claude-code)