### PR TITLE
Bump actions/checkout to v6 in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: wdl-ci
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary

The README's example workflows still showed `actions/checkout@v4` (which runs on the deprecated Node 20 runtime). Update all three to `actions/checkout@v6` (Node 24).

Removing the Node deprecation warning from old `checkout` was the original motivation for this whole round of work, so the copy-paste examples shouldn't reintroduce it for anyone following the docs.

Plain `@v6` tag form is used (rather than a SHA pin) since these are illustrative examples; a consumer's own Renovate would pin them.

## Test plan

- [x] `static-checks` + `docker-smoke` pass (docs-only change; no functional impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)